### PR TITLE
Fix not string types with allow_regex

### DIFF
--- a/llm_eval/checks.py
+++ b/llm_eval/checks.py
@@ -952,11 +952,14 @@ class ToolCallsCheck(Check):
                 for key, val in dict(self.function_arguments).items():
                     if key in tool_call_function_arguments:
                         tool_call_value = tool_call_function_arguments.pop(key)
-                        if self.allow_regex:
+                        # since re.search does not allow non-string types
+                        # first handle bools/ints/floats that are equal
+                        # or check if none
+                        if tool_call_value == val or tool_call_value is None and val is None:
+                            num_arguments_successful += 1
+                        elif self.allow_regex and isinstance(val, str):
                             if re.search(val, tool_call_value):
                                 num_arguments_successful += 1
-                        elif tool_call_value == val:
-                            num_arguments_successful += 1
                 if self.penalize_extraneous_arguments:
                     num_arguments_successful -= len(tool_call_function_arguments)
                     num_arguments_successful = max(num_arguments_successful, 0)

--- a/llm_eval/checks.py
+++ b/llm_eval/checks.py
@@ -957,8 +957,7 @@ class ToolCallsCheck(Check):
                         # or check if none
                         if tool_call_value == val or tool_call_value is None and val is None:
                             num_arguments_successful += 1
-                        elif self.allow_regex and isinstance(val, str):
-                            if re.search(val, tool_call_value):
+                        elif self.allow_regex and isinstance(val, str) and re.search(val, tool_call_value):
                                 num_arguments_successful += 1
                 if self.penalize_extraneous_arguments:
                     num_arguments_successful -= len(tool_call_function_arguments)

--- a/llm_eval/checks.py
+++ b/llm_eval/checks.py
@@ -958,7 +958,7 @@ class ToolCallsCheck(Check):
                         if tool_call_value == val or tool_call_value is None and val is None:
                             num_arguments_successful += 1
                         elif self.allow_regex and isinstance(val, str) and re.search(val, tool_call_value):
-                                num_arguments_successful += 1
+                            num_arguments_successful += 1
                 if self.penalize_extraneous_arguments:
                     num_arguments_successful -= len(tool_call_function_arguments)
                     num_arguments_successful = max(num_arguments_successful, 0)

--- a/llm_eval/checks.py
+++ b/llm_eval/checks.py
@@ -965,7 +965,6 @@ class ToolCallsCheck(Check):
                             )
                         ):
                             num_arguments_successful += 1
-                            num_arguments_successful += 1
                 if self.penalize_extraneous_arguments:
                     num_arguments_successful -= len(tool_call_function_arguments)
                     num_arguments_successful = max(num_arguments_successful, 0)

--- a/llm_eval/checks.py
+++ b/llm_eval/checks.py
@@ -955,9 +955,6 @@ class ToolCallsCheck(Check):
                         # since re.search does not allow non-string types
                         # first handle bools/ints/floats that are equal
                         # or check if none
-                        # since re.search does not allow non-string types
-                        # first handle bools/ints/floats that are equal
-                        # or check if none
                         if (
                             (tool_call_value == val)
                             or (tool_call_value is None and val is None)

--- a/llm_eval/checks.py
+++ b/llm_eval/checks.py
@@ -955,9 +955,19 @@ class ToolCallsCheck(Check):
                         # since re.search does not allow non-string types
                         # first handle bools/ints/floats that are equal
                         # or check if none
-                        if tool_call_value == val or tool_call_value is None and val is None:
+                        # since re.search does not allow non-string types
+                        # first handle bools/ints/floats that are equal
+                        # or check if none
+                        if (
+                            (tool_call_value == val)
+                            or (tool_call_value is None and val is None)
+                            or (
+                                self.allow_regex
+                                and isinstance(val, str)
+                                and re.search(val, tool_call_value)
+                            )
+                        ):
                             num_arguments_successful += 1
-                        elif self.allow_regex and isinstance(val, str) and re.search(val, tool_call_value):
                             num_arguments_successful += 1
                 if self.penalize_extraneous_arguments:
                     num_arguments_successful -= len(tool_call_function_arguments)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -2331,11 +2331,23 @@ def test__ToolCallsCheck__multiple_functions():  # noqa
 def test__ToolCallsCheck__allow_regex():  # noqa
     check = ToolCallsCheck(
         function_name='get_current_weather',
-        function_arguments={'location': 'Boston', 'unit': 'fahrenheit', 'temperature': 70, 'raining': False, 'uv_index': None},
+        function_arguments={
+            'location': 'Boston',
+            'unit': 'fahrenheit',
+            'temperature': 70,
+            'raining': False,
+            'uv_index': None
+        },
         allow_regex=True,
     )
     result = check(ResponseData(response=[{
-        'arguments': {'location':'Boston, MA', 'unit':'fahrenheit', 'temperature': 70, 'raining': False, 'uv_index': None},
+        'arguments': {
+            'location':'Boston, MA',
+            'unit':'fahrenheit',
+            'temperature': 70,
+            'raining': False,
+            'uv_index': None
+        },
         'name': 'get_current_weather',
     }]))
     assert isinstance(result, CheckResult)
@@ -2343,7 +2355,11 @@ def test__ToolCallsCheck__allow_regex():  # noqa
     assert result.value == 1
     assert result.metadata['function_name'] == 'get_current_weather'
     assert result.metadata['function_arguments'] == {
-        'location': 'Boston', 'unit': 'fahrenheit', 'temperature': 70, 'raining': False, 'uv_index': None,
+        'location': 'Boston',
+        'unit': 'fahrenheit',
+        'temperature': 70,
+        'raining': False,
+        'uv_index': None,
     }
     assert result.metadata['allow_regex'] is True
     assert result.metadata['check_type'] == CheckType.TOOL_CALL
@@ -2389,11 +2405,23 @@ def test__ToolCallsCheck__incorrect_function_name():  # noqa
 def test__ToolCallsCheck__allow_regex_partial_correct():  # noqa
     check = ToolCallsCheck(
         function_name='get_current_weather',
-        function_arguments={'location': 'Boston', 'unit': 'fahrenheit', 'temperature': 70, 'raining': False, 'uv_index': None},
+        function_arguments={
+            'location': 'Boston',
+            'unit': 'fahrenheit',
+            'temperature': 70,
+            'raining': False,
+            'uv_index': None
+        },
         allow_regex=True,
     )
     result = check(ResponseData(response=[{
-        'arguments': {'location':'Boston, MA', 'unit':'fahrenheit', 'temperature': 70, 'raining': True, 'uv_index': 0},
+        'arguments': {
+            'location':'Boston, MA',
+            'unit':'fahrenheit',
+            'temperature': 70,
+            'raining': True,
+            'uv_index': 0
+        },
         'name': 'get_current_weather',
     }]))
     assert isinstance(result, CheckResult)
@@ -2401,7 +2429,11 @@ def test__ToolCallsCheck__allow_regex_partial_correct():  # noqa
     assert result.value == 0.6
     assert result.metadata['function_name'] == 'get_current_weather'
     assert result.metadata['function_arguments'] == {
-        'location': 'Boston', 'unit': 'fahrenheit', 'temperature': 70, 'raining': False, 'uv_index': None,
+        'location': 'Boston',
+        'unit': 'fahrenheit',
+        'temperature': 70,
+        'raining': False,
+        'uv_index': None,
     }
     assert result.metadata['allow_regex'] is True
     assert result.metadata['check_type'] == CheckType.TOOL_CALL

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -2336,7 +2336,7 @@ def test__ToolCallsCheck__allow_regex():  # noqa
             'unit': 'fahrenheit',
             'temperature': 70,
             'raining': False,
-            'uv_index': None
+            'uv_index': None,
         },
         allow_regex=True,
     )
@@ -2346,7 +2346,7 @@ def test__ToolCallsCheck__allow_regex():  # noqa
             'unit':'fahrenheit',
             'temperature': 70,
             'raining': False,
-            'uv_index': None
+            'uv_index': None,
         },
         'name': 'get_current_weather',
     }]))
@@ -2410,7 +2410,7 @@ def test__ToolCallsCheck__allow_regex_partial_correct():  # noqa
             'unit': 'fahrenheit',
             'temperature': 70,
             'raining': False,
-            'uv_index': None
+            'uv_index': None,
         },
         allow_regex=True,
     )
@@ -2420,7 +2420,7 @@ def test__ToolCallsCheck__allow_regex_partial_correct():  # noqa
             'unit':'fahrenheit',
             'temperature': 70,
             'raining': True,
-            'uv_index': 0
+            'uv_index': 0,
         },
         'name': 'get_current_weather',
     }]))

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -2331,11 +2331,11 @@ def test__ToolCallsCheck__multiple_functions():  # noqa
 def test__ToolCallsCheck__allow_regex():  # noqa
     check = ToolCallsCheck(
         function_name='get_current_weather',
-        function_arguments={'location': 'Boston', 'unit': 'fahrenheit'},
+        function_arguments={'location': 'Boston', 'unit': 'fahrenheit', 'temperature': 70, 'raining': False, 'uv_index': None},
         allow_regex=True,
     )
     result = check(ResponseData(response=[{
-        'arguments': {'location':'Boston, MA', 'unit':'fahrenheit'},
+        'arguments': {'location':'Boston, MA', 'unit':'fahrenheit', 'temperature': 70, 'raining': False, 'uv_index': None},
         'name': 'get_current_weather',
     }]))
     assert isinstance(result, CheckResult)
@@ -2343,7 +2343,7 @@ def test__ToolCallsCheck__allow_regex():  # noqa
     assert result.value == 1
     assert result.metadata['function_name'] == 'get_current_weather'
     assert result.metadata['function_arguments'] == {
-        'location': 'Boston', 'unit': 'fahrenheit',
+        'location': 'Boston', 'unit': 'fahrenheit', 'temperature': 70, 'raining': False, 'uv_index': None,
     }
     assert result.metadata['allow_regex'] is True
     assert result.metadata['check_type'] == CheckType.TOOL_CALL
@@ -2385,6 +2385,26 @@ def test__ToolCallsCheck__incorrect_function_name():  # noqa
     assert isinstance(result, CheckResult)
     assert result.success is False
     assert result.value == 0
+
+def test__ToolCallsCheck__allow_regex_partial_correct():  # noqa
+    check = ToolCallsCheck(
+        function_name='get_current_weather',
+        function_arguments={'location': 'Boston', 'unit': 'fahrenheit', 'temperature': 70, 'raining': False, 'uv_index': None},
+        allow_regex=True,
+    )
+    result = check(ResponseData(response=[{
+        'arguments': {'location':'Boston, MA', 'unit':'fahrenheit', 'temperature': 70, 'raining': True, 'uv_index': 0},
+        'name': 'get_current_weather',
+    }]))
+    assert isinstance(result, CheckResult)
+    assert result.success is False
+    assert result.value == 0.6
+    assert result.metadata['function_name'] == 'get_current_weather'
+    assert result.metadata['function_arguments'] == {
+        'location': 'Boston', 'unit': 'fahrenheit', 'temperature': 70, 'raining': False, 'uv_index': None,
+    }
+    assert result.metadata['allow_regex'] is True
+    assert result.metadata['check_type'] == CheckType.TOOL_CALL
 
 def test__ToolCallsCheck__empty_string_response():  # noqa
     check = ToolCallsCheck(


### PR DESCRIPTION
Fixes checks with allow_regex=True alongside args that are not strings

It was crashing with
```python
import re
re.search("abc", True)


TypeError: expected string or bytes-like object
```