### PR TITLE
Support MistralAI (service) calls

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - joblib=1.4
   - markdown=3.4
   - markdownify=0.11
+  - mistralai=1.1
   - numpy=1.26
   - openai=1.25
   - pandas=2.2

--- a/examples/3_callable_checks_and_candidates.ipynb
+++ b/examples/3_callable_checks_and_candidates.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,19 +22,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Num checks: 3\n",
-      "Num passed: 3\n",
-      "Perc Passed: 100.0%\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from llm_eval.candidates import CandidateResponse\n",
     "from llm_eval.eval import Eval\n",
@@ -42,10 +32,10 @@
     "def fake_candidate(input: dict) -> CandidateResponse:\n",
     "    fake_response = {'my_response': f\"This is a fake response for the prompt: '{str(input)}'.\"}\n",
     "    # all Candidates must return a CandidateResponse object\n",
-    "    return CandidateResponse(content=fake_response)\n",
+    "    return CandidateResponse(response=fake_response)\n",
     "\n",
     "eval_ = Eval(\n",
-    "    input={'my_prompt': \"This is a user's prompt.\"},\n",
+    "    input=[{'my_prompt': \"This is a user's prompt.\"}],\n",
     "    checks=[\n",
     "        # a ResponseData object is passed to all checks (Check or callable) from the Eval\n",
     "        lambda data: 'my_response' in data.response,\n",
@@ -83,7 +73,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/examples/candidates/additional_examples/mistral_ministral-8b-latest.yaml
+++ b/examples/candidates/additional_examples/mistral_ministral-8b-latest.yaml
@@ -1,0 +1,7 @@
+metadata:
+  name: MistralAI ministral-8b-latest
+candidate_type: MISTRALAI
+model: ministral-8b-latest
+parameters:
+  temperature: 0.01
+  max_tokens: 4096

--- a/llm_eval/candidates.py
+++ b/llm_eval/candidates.py
@@ -24,6 +24,8 @@ Candidates can also be passed to the EvalHarness (or Eval object) directory as a
 can be serialized into a dictionary and the information can be saved in the EvalResult object
 (evals.py).
 """
+
+import os
 import yaml
 from inspect import iscoroutinefunction
 from copy import deepcopy
@@ -34,8 +36,7 @@ from typing import Any, Callable, List, Literal, Type, Union
 from pydantic import BaseModel
 from openai import OpenAI
 from llm_eval.openai import (
-    MODEL_COST_PER_TOKEN,
-    OpenAIChatResponse,
+    MODEL_COST_PER_TOKEN as OPENAI_MODEL_COST_PER_TOKEN,
     OpenAICompletion,
     OpenAICompletionResponse,
     OpenAIToolsResponse,
@@ -46,12 +47,13 @@ from llm_eval.internal_utilities import (
     Registry,
 )
 
+
 @staticmethod
-def is_async_candidate(candidate: Callable | 'Candidate') -> bool:
+def is_async_candidate(candidate: Callable | "Candidate") -> bool:
     """Tests if the Candidate object or callable is an async function."""
     if iscoroutinefunction(candidate):
         return True
-    if hasattr(candidate, '__call__'):
+    if hasattr(candidate, "__call__"):
         return iscoroutinefunction(candidate.__call__)
     return False
 
@@ -61,6 +63,8 @@ class CandidateType(EnumMixin, Enum):
 
     OPENAI = auto()
     OPENAI_TOOLS = auto()
+    MISTRALAI = auto()
+    MISTRALAI_TOOLS = auto()
 
 
 class CandidateResponse(BaseModel):
@@ -88,7 +92,9 @@ class Candidate(DictionaryEqualsMixin, ABC):
 
     registry = Registry()
 
-    def __init__(self, metadata: dict | None = None, parameters: dict | None = None) -> None:  # noqa: D417
+    def __init__(
+        self, metadata: dict | None = None, parameters: dict | None = None
+    ) -> None:  # noqa: D417
         """
         Initialize a Candidate object.
 
@@ -109,15 +115,20 @@ class Candidate(DictionaryEqualsMixin, ABC):
     @classmethod
     def register(cls, candidate_type: str | Enum):  # noqa: ANN102
         """Register a subclass of Candidate."""
+
         def decorator(subclass: Type[Candidate]) -> Type[Candidate]:
-            assert issubclass(subclass, Candidate), \
-                f"Candidate '{candidate_type}' ({subclass.__name__}) must extend Candidate"
+            assert issubclass(
+                subclass, Candidate
+            ), f"Candidate '{candidate_type}' ({subclass.__name__}) must extend Candidate"
             cls.registry.register(type_name=candidate_type, item=subclass)
             return subclass
+
         return decorator
 
     @classmethod
-    def from_dict(cls, data: dict) -> Union['Candidate', List['Candidate']]:  # noqa: ANN102
+    def from_dict(
+        cls, data: dict
+    ) -> Union["Candidate", List["Candidate"]]:  # noqa: ANN102
         """
         Creates a Candidate object.
 
@@ -126,7 +137,7 @@ class Candidate(DictionaryEqualsMixin, ABC):
         `candidate_type` field that matches the type name of the registered Candidate subclass.
         """
         data = deepcopy(data)
-        candidate_type = data.pop('candidate_type', '')
+        candidate_type = data.pop("candidate_type", "")
         if candidate_type in cls.registry:
             return cls.registry.create_instance(type_name=candidate_type, **data)
         raise ValueError(f"Unknown type {candidate_type}")
@@ -136,23 +147,25 @@ class Candidate(DictionaryEqualsMixin, ABC):
         # value = self.model_dump(exclude_defaults=True, exclude_none=True)
         value = {}
         if self.metadata:
-            value['metadata'] = deepcopy(self.metadata)
+            value["metadata"] = deepcopy(self.metadata)
         if self.parameters:
-            value['parameters'] = deepcopy(self.parameters)
+            value["parameters"] = deepcopy(self.parameters)
         if self.candidate_type:
-            value['candidate_type'] = self.candidate_type
+            value["candidate_type"] = self.candidate_type
         return value
 
     @property
     def candidate_type(self) -> str | None:
         """The type of Candidate."""
         # check that self.__class__ has _type_name attribute
-        if hasattr(self.__class__, '_type_name'):
+        if hasattr(self.__class__, "_type_name"):
             return self.__class__._type_name.upper()
         return self.__class__.__name__
 
     @classmethod
-    def from_yaml(cls, path: str) -> Union['Candidate', List['Candidate']]:  # noqa: ANN102
+    def from_yaml(
+        cls, path: str
+    ) -> Union["Candidate", List["Candidate"]]:  # noqa: ANN102
         """
         Creates a Candidate object from a YAML file. This method requires the Candidate subclass to
         be registered via `Candidate.register(...)` before calling this method. It also requires
@@ -165,38 +178,42 @@ class Candidate(DictionaryEqualsMixin, ABC):
 
     def __str__(self) -> str:
         """Returns a string representation of the Candidate."""
-        parameters = '' if not self.parameters else f'\n            parameters={self.parameters},'
-        return dedent(f"""
+        parameters = (
+            ""
+            if not self.parameters
+            else f"\n            parameters={self.parameters},"
+        )
+        return dedent(
+            f"""
         {self.__class__.__name__}(
             metadata={self.metadata},
             {parameters}
         )
-        """).strip()
+        """
+        ).strip()
 
 
-@Candidate.register(CandidateType.OPENAI)
-class OpenAICandidate(Candidate):
+class ServiceCandidate(Candidate, ABC):
     """
-    Wrapper around the OpenAI API that allows the user to create an OpenAI candidate from a
+    Wrapper around a service API that allows the user to create a service candidate from a
     dictionary.
-
-    NOTE: the `OPENAI_API_KEY` environment variable must be set to use this class.
     """
 
     def __init__(  # noqa: D417
-            self,
-            model: str | None = None,
-            endpoint_url: str | None = None,
-            metadata: dict | None = None,
-            parameters: dict | None = None) -> None:
+        self,
+        model: str | None = None,
+        endpoint_url: str | None = None,
+        metadata: dict | None = None,
+        parameters: dict | None = None,
+    ) -> None:
         """
-        Initialize a OpenAICandidate object.
+        Initialize a Service object.
 
         Args:
             model:
-                The name of the OpenAI model to use (e.g. 'gpt-4o-mini').
+                The name of the model to use.
             endpoint_url:
-                This parameter is used when running against a local OpenAI-compatible API endpoint.
+                This parameter is used when running against a local service-compatible API endpoint.
             metadata:
                 A dictionary of metadata about the Candidate.
             parameters:
@@ -207,38 +224,65 @@ class OpenAICandidate(Candidate):
         self.model = model
         self.endpoint_url = endpoint_url
 
+    @property
+    @abstractmethod
+    def client(self):
+        """Return the client for the service."""
+
+    @property
+    @abstractmethod
+    def model_cost_per_token(self) -> float | None:
+        """
+        Return the cost per token for the model. This is used to calculate the cost of the
+        completion.
+        """
+
+    @abstractmethod
+    def _invoke_client(self, input: Any) -> Any:
+        """
+        Invoke the client with the input and return the response.
+        """
+
+    @abstractmethod
+    def _parse_response(self, response):
+        """
+        Get the desired attribute from the response object.
+        """
+
     def __call__(self, input: list[dict[str, str]]) -> CandidateResponse:  # noqa: A002
         """Invokes the underlying model with the input and returns the response."""
-        client = OpenAICompletion(
-            client=OpenAI(base_url=self.endpoint_url),
-            model=self.model or self.endpoint_url,
-            **self.parameters or {},
-        )
-        response: OpenAIChatResponse = client(input)
-        prompt_tokens = response.usage.get('prompt_tokens')
-        completion_tokens = response.usage.get('completion_tokens')
-        total_tokens = response.usage.get('total_tokens')
+        response = self._invoke_client(input)
+        prompt_tokens = response.usage.get("prompt_tokens")
+        completion_tokens = response.usage.get("completion_tokens")
+        total_tokens = response.usage.get("total_tokens")
 
-        cost_per_token = MODEL_COST_PER_TOKEN.get(self.model)
+        cost_per_token = self.model_cost_per_token
         if cost_per_token and prompt_tokens and completion_tokens:
-            prompt_cost = cost_per_token['input'] * prompt_tokens
-            completion_cost = cost_per_token['output'] * completion_tokens
+            prompt_cost = cost_per_token["input"] * prompt_tokens
+            completion_cost = cost_per_token["output"] * completion_tokens
             total_cost = prompt_cost + completion_cost
         else:
             prompt_cost = None
             completion_cost = None
             total_cost = None
 
+        parsed_response = self._parse_response(response)
+        completion_characters = len(parsed_response) if isinstance(parsed_response, str) else None
         return CandidateResponse(
-            response=response.content,
+            response=parsed_response,
             metadata={
-                'prompt_tokens': prompt_tokens,
-                'completion_tokens': completion_tokens,
-                'total_tokens': total_tokens,
-                'prompt_cost': prompt_cost,
-                'completion_cost': completion_cost,
-                'total_cost': total_cost,
-                'completion_characters': len(response.content),
+                "type": (
+                    "tools"
+                    if isinstance(response, OpenAIToolsResponse)
+                    else "completion"
+                ),
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": total_tokens,
+                "prompt_cost": prompt_cost,
+                "completion_cost": completion_cost,
+                "total_cost": total_cost,
+                "completion_characters": completion_characters,
             },
         )
 
@@ -246,14 +290,14 @@ class OpenAICandidate(Candidate):
         """Return a dictionary representation of the Candidate."""
         value = super().to_dict()
         if self.model:
-            value['model'] = self.model
+            value["model"] = self.model
         if self.endpoint_url:
-            value['endpoint_url'] = self.endpoint_url
+            value["endpoint_url"] = self.endpoint_url
         return value
 
 
-@Candidate.register(CandidateType.OPENAI_TOOLS)
-class OpenAIToolsCandidate(Candidate):
+@Candidate.register(CandidateType.OPENAI)
+class OpenAICandidate(ServiceCandidate):
     """
     Wrapper around the OpenAI API that allows the user to create an OpenAI candidate from a
     dictionary.
@@ -261,14 +305,46 @@ class OpenAIToolsCandidate(Candidate):
     NOTE: the `OPENAI_API_KEY` environment variable must be set to use this class.
     """
 
+    def model_cost_per_token(self) -> float | None:
+        """
+        Return the cost per token for the model. This is used to calculate the cost of the
+        completion.
+        """
+        return OPENAI_MODEL_COST_PER_TOKEN.get(self.model)
+
+    def client(self) -> OpenAICompletion:
+        """Return the client for the OpenAI service."""
+        return OpenAICompletion(
+            client=OpenAI(base_url=self.endpoint_url),
+            model=self.model,
+            **self.parameters or {},
+        )
+
+    def _invoke_client(self, input: Any) -> Any:
+        """
+        Invoke the client with the input and return the response.
+        """
+        return self.client(input)
+
+
+@Candidate.register(CandidateType.OPENAI_TOOLS)
+class OpenAIToolsCandidate(OpenAICandidate):
+    """
+    Wrapper around the OpenAI Tools API that allows the user to create an OpenAI candidate from a
+    dictionary.
+
+    NOTE: the `OPENAI_API_KEY` environment variable must be set to use this class.
+    """
+
     def __init__(  # noqa: D417
-            self,
-            tools: list[dict],
-            tool_choice: Literal['none', 'auto', 'required'] | dict[str] = 'required',
-            model: str | None = None,
-            endpoint_url: str | None = None,
-            metadata: dict | None = None,
-            parameters: dict | None = None) -> None:
+        self,
+        tools: list[dict],
+        tool_choice: Literal["none", "auto", "required"] | dict[str] = "required",
+        model: str | None = None,
+        endpoint_url: str | None = None,
+        metadata: dict | None = None,
+        parameters: dict | None = None,
+    ) -> None:
         """
         Initialize a OpenAIToolsCandidate object.
 
@@ -290,60 +366,142 @@ class OpenAIToolsCandidate(Candidate):
             parameters:
                 A dictionary of model-specific parameters (e.g. `temperature`).
         """  # noqa
-        super().__init__(metadata=metadata, parameters=parameters)
-        assert model or endpoint_url, "model or endpoint_url must be provided"
-        self.model = model
-        self.endpoint_url = endpoint_url
+        super().__init__(
+            model=model,
+            endpoint_url=endpoint_url,
+            metadata=metadata,
+            parameters=parameters,
+        )
         self.tools = tools
         self.tool_choice = tool_choice
 
-    def __call__(self, input: dict) -> CandidateResponse:  # noqa: A002
-        """Invokes the underlying model with the input/tools and returns the response."""
-        client = OpenAICompletion(
-            client=OpenAI(base_url=self.endpoint_url),
-            model=self.model or self.endpoint_url,
-            **self.parameters or {},
+    def _invoke_client(self, input: Any) -> Any:
+        """
+        Invoke the client with the input and return the response.
+        """
+        return self.client(
+            messages=input, tools=self.tools, tool_choice=self.tool_choice
         )
-        response: OpenAIToolsResponse | OpenAICompletionResponse = client(
-            messages=input,
-            tools=self.tools,
-            tool_choice=self.tool_choice,
-        )
-        prompt_tokens = response.usage.get('prompt_tokens')
-        completion_tokens = response.usage.get('completion_tokens')
-        total_tokens = response.usage.get('total_tokens')
 
-        cost_per_token = MODEL_COST_PER_TOKEN.get(self.model)
-        if cost_per_token and prompt_tokens and completion_tokens:
-            prompt_cost = cost_per_token['input'] * prompt_tokens
-            completion_cost = cost_per_token['output'] * completion_tokens
-            total_cost = prompt_cost + completion_cost
-        else:
-            prompt_cost = None
-            completion_cost = None
-            total_cost = None
-
-        content = response.tools if isinstance(response, OpenAIToolsResponse) else response.content
-        return CandidateResponse(
-            response=content,
-            metadata={
-                'type': 'tools' if isinstance(response, OpenAIToolsResponse) else 'completion',
-                'prompt_tokens': prompt_tokens,
-                'completion_tokens': completion_tokens,
-                'total_tokens': total_tokens,
-                'prompt_cost': prompt_cost,
-                'completion_cost': completion_cost,
-                'total_cost': total_cost,
-            },
+    def _parse_response(self, response):
+        """
+        Get the desired attribute from the response object.
+        """
+        return (
+            response.tools
+            if isinstance(response, OpenAIToolsResponse)
+            else response.content
         )
 
     def to_dict(self) -> dict:
         """Return a dictionary representation of the Candidate."""
         value = super().to_dict()
-        if self.model:
-            value['model'] = self.model
-        if self.endpoint_url:
-            value['endpoint_url'] = self.endpoint_url
-        value['tools'] = self.tools
-        value['tool_choice'] = self.tool_choice
+        value["tools"] = self.tools
+        value["tool_choice"] = self.tool_choice
         return value
+
+
+@Candidate.register(CandidateType.MISTRALAI)
+class MistralAICandidate(ServiceCandidate):
+    """
+    Wrapper around the MistralAI API that allows the user to create an MistralAI candidate from a
+    dictionary.
+
+    NOTE: the `MISTRAL_API_KEY` environment variable must be set to use this class.
+    """
+
+    @property
+    def client(self):
+        """Return the client for the OpenAI service."""
+        from mistralai import Mistral
+        from llm_eval.mistralai import MistralAICompletion
+
+        parameters = self.parameters or {}
+        api_key = parameters.pop("api_key", os.getenv("MISTRAL_API_KEY"))
+        return MistralAICompletion(
+            client=Mistral(api_key=api_key, server_url=self.endpoint_url),
+            model=self.model,
+            **parameters,
+        )
+
+    @property
+    def model_cost_per_token(self):
+        from llm_eval.mistralai import (
+            MODEL_COST_PER_TOKEN as MISTRAL_MODEL_COST_PER_TOKEN,
+        )
+
+        return MISTRAL_MODEL_COST_PER_TOKEN.get(self.model)
+
+    def _invoke_client(self, input: Any) -> Any:
+        """
+        Invoke the client with the input and return the response.
+        """
+        return self.client(messages=input)
+
+
+@Candidate.register(CandidateType.MISTRALAI_TOOLS)
+class MistralAIToolsCandidate(MistralAICandidate):
+    """
+    Wrapper around the MistralAI Tools API that allows the user to create an MistralAI candidate
+    from a dictionary.
+
+    NOTE: the `MISTRAL_API_KEY` environment variable must be set to use this class.
+    """
+
+    def __init__(  # noqa: D417
+        self,
+        tools: list[dict],
+        tool_choice: Literal["auto", "any", "none"] | dict[str] = "auto",
+        model: str | None = None,
+        endpoint_url: str | None = None,
+        metadata: dict | None = None,
+        parameters: dict | None = None,
+    ) -> None:
+        """
+        Initialize a MistralAIToolsCandidate object.
+
+        Args:
+            tools:
+                A list of tools to use with the MistralAI model. See
+                https://docs.mistral.ai/capabilities/function_calling/ for more
+                information.
+            tool_choice:
+                Select from "auto", "any", "none"; for more information, see
+                https://docs.mistral.ai/capabilities/function_calling/#tool_choice.
+            model:
+                The name of the MistralAI model to use (e.g. 'mistral-large-latest').
+            endpoint_url:
+                This parameter is used when running against a local MistralAI-compatible API
+                endpoint.
+            metadata:
+                A dictionary of metadata about the Candidate.
+            parameters:
+                A dictionary of model-specific parameters (e.g. `temperature`).
+        """
+        super().__init__(
+            model=model,
+            endpoint_url=endpoint_url,
+            metadata=metadata,
+            parameters=parameters,
+        )
+        self.tools = tools
+        self.tool_choice = tool_choice
+
+    def _invoke_client(self, input: Any) -> Any:
+        """
+        Invoke the client with the input and return the response.
+        """
+        return self.client(
+            messages=input, tools=self.tools, tool_choice=self.tool_choice
+        )
+
+    def _parse_response(self, response):
+        """
+        Get the desired attribute from the response object.
+        """
+        from llm_eval.mistralai import MistralAIToolsResponse
+        return (
+            response.tools
+            if isinstance(response, MistralAIToolsResponse)
+            else response.content
+        )

--- a/llm_eval/candidates.py
+++ b/llm_eval/candidates.py
@@ -34,7 +34,7 @@ from copy import deepcopy
 from abc import ABC, abstractmethod
 from enum import Enum, auto
 from textwrap import dedent
-from typing import Any, Callable, List, Literal, Type, Union, TYPE_CHECKING
+from typing import Any, Callable, Literal, TYPE_CHECKING
 from pydantic import BaseModel
 from openai import OpenAI
 from llm_eval.openai import (
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
 
 
 @staticmethod
-def is_async_candidate(candidate: Callable | "Candidate") -> bool:
+def is_async_candidate(candidate: Callable | Candidate) -> bool:
     """Tests if the Candidate object or callable is an async function."""
     if iscoroutinefunction(candidate):
         return True
@@ -126,7 +126,7 @@ class Candidate(DictionaryEqualsMixin, ABC):
     def register(cls, candidate_type: str | Enum):  # noqa: ANN102
         """Register a subclass of Candidate."""
 
-        def decorator(subclass: Type[Candidate]) -> Type[Candidate]:
+        def decorator(subclass: type[Candidate]) -> type[Candidate]:
             assert issubclass(
                 subclass,
                 Candidate,
@@ -138,9 +138,9 @@ class Candidate(DictionaryEqualsMixin, ABC):
 
     @classmethod
     def from_dict(
-        cls: Type["Candidate"],
+        cls: type[Candidate],
         data: dict,
-    ) -> Union["Candidate", List["Candidate"]]:
+    ) -> Candidate | list[Candidate]:
         """
         Creates a Candidate object.
 
@@ -176,9 +176,9 @@ class Candidate(DictionaryEqualsMixin, ABC):
 
     @classmethod
     def from_yaml(
-        cls: Type["Candidate"],
+        cls: type[Candidate],
         path: str,
-    ) -> Union["Candidate", List["Candidate"]]:
+    ) -> Candidate | list[Candidate]:
         """
         Creates a Candidate object from a YAML file. This method requires the Candidate subclass to
         be registered via `Candidate.register(...)` before calling this method. It also requires
@@ -428,7 +428,7 @@ class MistralAICandidate(ServiceCandidate):
     """
 
     @property
-    def client_callable(self) -> "MistralAICompletion":
+    def client_callable(self) -> MistralAICompletion:
         """Return the client for the OpenAI service."""
         from mistralai import Mistral
         from llm_eval.mistralai import MistralAICompletion
@@ -456,7 +456,7 @@ class MistralAICandidate(ServiceCandidate):
     def _invoke_client_callable(
         self,
         input: list[dict[str, str]],  # noqa: A002
-    ) -> "MistralAICompletionResponse" | "MistralAIToolsResponse":
+    ) -> MistralAICompletionResponse | MistralAIToolsResponse:
         """Invoke the client with the input and return the response."""
         return self.client_callable(messages=input)
 
@@ -513,7 +513,7 @@ class MistralAIToolsCandidate(MistralAICandidate):
     def _invoke_client_callable(
         self,
         input: list[dict[str, str]],  # noqa: A002
-    ) -> "MistralAICompletionResponse" | "MistralAIToolsResponse":
+    ) -> MistralAICompletionResponse | MistralAIToolsResponse:
         """Invoke the client with the input and return the response."""
         return self.client_callable(
             messages=input,
@@ -523,7 +523,7 @@ class MistralAIToolsCandidate(MistralAICandidate):
 
     def _parse_response(
         self,
-        response: "MistralAICompletionResponse" | "MistralAIToolsResponse",
+        response: MistralAICompletionResponse | MistralAIToolsResponse,
     ) -> str | dict:
         """Get the desired attribute from the response object."""
         from llm_eval.mistralai import MistralAIToolsResponse

--- a/llm_eval/mistralai.py
+++ b/llm_eval/mistralai.py
@@ -1,0 +1,257 @@
+"""Contains helper functions for interacting with MistralAI models."""
+
+from abc import ABC
+import time
+from typing import Callable
+import json
+
+from mistralai import Mistral
+from pydantic import BaseModel, SerializeAsAny
+
+# https://mistral.ai/technology/#pricing
+CHAT_MODEL_COST_PER_TOKEN = {
+    # large
+    'mistral-large-latest': {'input': 2.00 / 1_000_000, 'output': 6.00 / 1_000_000},
+    'mistral-large-2407': {'input': 2.00 / 1_000_000, 'output': 6.00 / 1_000_000},
+    # small
+    'mistral-small-latest': {'input': 0.20 / 1_000_000, 'output': 0.60 / 1_000_000},
+    'mistral-small-2409': {'input': 0.20 / 1_000_000, 'output': 0.60 / 1_000_000},
+    # codestral
+    'codestral-latest': {'input': 0.20 / 1_000_000, 'output': 0.60 / 1_000_000},
+    'codestral-2405': {'input': 0.20 / 1_000_000, 'output': 0.60 / 1_000_000},
+    # ministral 3b
+    'ministral-3b-latest': {'input': 0.04 / 1_000_000, 'output': 0.04 / 1_000_000},
+    'ministral-3b-2410': {'input': 0.04 / 1_000_000, 'output': 0.04 / 1_000_000},
+    # ministral 8b
+    'ministral-8b-latest': {'input': 0.10 / 1_000_000, 'output': 0.10 / 1_000_000},
+    'ministral-8b-2410': {'input': 0.10 / 1_000_000, 'output': 0.10 / 1_000_000},
+    # pixtral
+    'pixtral-latest': {'input': 0.15 / 1_000_000, 'output': 0.15 / 1_000_000},
+    'pixtral-12b-2409': {'input': 0.15 / 1_000_000, 'output': 0.15 / 1_000_000},
+    # mistral-nemo
+    'mistral-nemo': {'input': 0.15 / 1_000_000, 'output': 0.15 / 1_000_000},
+    # open-mistral
+    'open-mistral-7b': {'input': 0.25 / 1_000_000, 'output': 0.25 / 1_000_000},
+    # open-mixtral
+    'open-mixtral-8x7b': {'input': 0.70 / 1_000_000, 'output': 0.70 / 1_000_000},
+    # open-mixtral
+    'open-mixtral-8x22b': {'input': 2.00 / 1_000_000, 'output': 6.00 / 1_000_000},
+}
+
+EMBEDDING_MODEL_COST_PER_TOKEN = {
+    'mistral-embed': 0.10 / 1_000_000,
+}
+
+MODEL_COST_PER_TOKEN = CHAT_MODEL_COST_PER_TOKEN | EMBEDDING_MODEL_COST_PER_TOKEN
+
+
+class MistralAIResponse(BaseModel):
+    """Base class for MistralAI responses."""
+
+    object_name: str
+    model: str
+    created: int
+    metadata: dict | SerializeAsAny[BaseModel] | None = None
+    # https://platform.openai.com/docs/guides/chat-completions/response-format
+    # stop: API returned complete message, or a message terminated by one of the stop sequences
+    # provided via the stop parameter
+    # length: Incomplete model output due to max_tokens parameter or token limit
+    # function_call: The model decided to call a function
+    # content_filter: Omitted content due to a flag from our content filters
+    # null: API response still in progress or incomplete
+    finish_reason: str | None = None
+
+
+class MistralAICompletionResponse(MistralAIResponse):
+    """Stores the parsed response/content of an MistralAI chat completion chunk."""
+
+    content: str
+
+
+class MistralAIToolsResponse(MistralAIResponse):
+    """Stores the parsed response/content of an MistralAI tool rseult."""
+
+    tools: list[dict]
+    role: str | None = None
+    usage: dict | None = None
+    duration_seconds: float | None = None
+
+
+class MistralAIChatResponse(MistralAICompletionResponse):
+    """Stores the parsed response/content of an MistralAI chat completion chunk."""
+
+    content: str
+    role: str | None = None
+    usage: dict | None = None
+    duration_seconds: float | None = None
+
+
+class MistralAICompletionWrapperBase(ABC):
+    """
+    Wrapper for MistralAI API which provides a simple interface for calling the
+    chat.completions.create method and parsing the response.
+
+    The user can specify the model name, timeout, stream, and other parameters for the API call
+    either in the constructor or when calling the object. If the latter, the parameters specified
+    when calling the object will override the parameters specified in the constructor.
+    """
+
+    def __init__(
+        self,
+        client: Mistral,
+        model: str,
+        stream_callback: Callable | None = None,
+        **model_kwargs: dict,
+    ) -> None:
+        self.client = client
+        self.model = model
+        self.stream_callback = stream_callback
+        self.model_parameters = model_kwargs or {}
+
+    @staticmethod
+    def _parse_response(
+        response,
+    ) -> MistralAIChatResponse | MistralAICompletionResponse:  # noqa: ANN001
+        # chat.completion is the latest response type
+        # 'chat.completion.chunk' indicates streaming
+        if len(response.choices) != 1:
+            raise ValueError(
+                f"Currently only handling one choice, received {len(response.choices)}"
+            )  # noqa: E501
+
+        is_function_call = (
+            response.object == "chat.completion"
+            and hasattr(response.choices[0], "message")
+            and hasattr(response.choices[0].message, "tool_calls")
+            and response.choices[0].message.tool_calls
+        )
+
+        def _try_parse(value):  # noqa
+            if not value:
+                return None
+            try:
+                return json.loads(value)
+            except:  # noqa: E722
+                return value
+
+        if is_function_call:
+            tools = [
+                {
+                    "type": tool.type,
+                    "name": tool.function.name,
+                    "arguments": _try_parse(tool.function.arguments),
+                }
+                for tool in response.choices[0].message.tool_calls
+            ]
+            return MistralAIToolsResponse(
+                object_name="tools",
+                model=response.model,
+                created=response.created,
+                tools=tools,
+                finish_reason=response.choices[0].finish_reason,
+                role=response.choices[0].message.role,
+                usage=dict(response.usage) if response.usage else None,
+            )
+        is_streaming = response.object == "chat.completion.chunk"
+        is_legacy_streaming = (
+            (response.object == "text_completion")
+            and hasattr(response.choices[0], "delta")
+            and response.choices[0].delta
+        )
+        is_non_streaming = response.object == "chat.completion"
+        is_legacy_non_streaming = (
+            (response.object == "text_completion")
+            and hasattr(response.choices[0], "message")
+            and response.choices[0].message
+        )
+
+        assert (
+            is_streaming
+            or is_legacy_streaming
+            or is_non_streaming
+            or is_legacy_non_streaming
+        ), f"Unexpected response object: {response.object}"  # noqa: E501
+
+        if is_streaming or is_legacy_streaming:
+            return MistralAICompletionResponse(
+                object_name=response.object,
+                model=response.model,
+                created=response.created,
+                content=response.choices[0].delta.content,
+                finish_reason=response.choices[0].finish_reason,
+            )
+        if is_non_streaming or is_legacy_non_streaming:
+            return MistralAIChatResponse(
+                object_name=response.object,
+                model=response.model,
+                created=response.created,
+                content=response.choices[0].message.content,
+                finish_reason=response.choices[0].finish_reason,
+                role=response.choices[0].message.role,
+                usage=dict(response.usage) if response.usage else None,
+            )
+        raise ValueError(f"Unexpected response object: {response.object}")
+
+
+class MistralAICompletion(MistralAICompletionWrapperBase):
+    """
+    Non-Async wrapper for MistralAI API which provides a simple interface for calling the
+    chat.completions.create method and parsing the response.
+    """
+
+    def __call__(
+        self,
+        messages: list[str],
+        model: str | None = None,
+        stream_callback: Callable | None = None,
+        **model_kwargs: dict,
+    ) -> MistralAIChatResponse | MistralAICompletionResponse:
+        """Non-Async __call__."""
+        model = model or self.model
+        stream_callback = stream_callback or self.stream_callback
+        model_parameters = model_kwargs or self.model_parameters
+        if stream_callback:
+            chunks = []
+            start_time = time.time()
+            response = self.client.chat.stream(
+                model=model,
+                messages=messages,
+                stream=True,
+                **model_parameters,
+            )
+            for chunk in response:
+                if chunk.choices[0].delta.content:
+                    chunk_parsed = MistralAICompletion._parse_response(chunk)
+                    stream_callback(chunk_parsed)
+                    chunks.append(chunk_parsed)
+            # send a final chunk with no content to indicate the end of the stream
+            stream_callback(
+                MistralAICompletionResponse(
+                    object_name=chunk.object,
+                    model=chunk.model,
+                    created=chunk.created,
+                    content="",
+                    finish_reason=chunk.choices[0].finish_reason,  # last finish reason
+                )
+            )
+            end_time = time.time()
+            return MistralAIChatResponse(
+                object_name="chat.stream",
+                model=chunks[0].model,
+                created=chunks[-1].created,
+                role="assistant",
+                duration_seconds=end_time - start_time,
+                content="".join([chunk.content for chunk in chunks]),
+                finish_reason=chunk.choices[0].finish_reason,
+            )
+        start_time = time.time()
+        response = self.client.chat.complete(
+            model=model,
+            messages=messages,
+            stream=False,
+            **model_parameters,
+        )
+        end_time = time.time()
+        response = MistralAICompletion._parse_response(response)
+        response.duration_seconds = end_time - start_time
+        return response

--- a/llm_eval/mistralai.py
+++ b/llm_eval/mistralai.py
@@ -6,6 +6,7 @@ from typing import Callable, Literal
 import json
 
 from mistralai import Mistral
+from mistralai.models.chatcompletionresponse import ChatCompletionResponse
 from pydantic import BaseModel, SerializeAsAny
 
 # https://mistral.ai/technology/#pricing
@@ -110,8 +111,8 @@ class MistralAICompletionWrapperBase(ABC):
 
     @staticmethod
     def _parse_response(
-        response,
-    ) -> MistralAIChatResponse | MistralAICompletionResponse:  # noqa: ANN001
+        response: ChatCompletionResponse,
+    ) -> MistralAIChatResponse | MistralAICompletionResponse:
         # chat.completion is the latest response type
         # 'chat.completion.chunk' indicates streaming
         if hasattr(response, "data"):
@@ -119,8 +120,8 @@ class MistralAICompletionWrapperBase(ABC):
 
         if len(response.choices) != 1:
             raise ValueError(
-                f"Currently only handling one choice, received {len(response.choices)}"
-            )  # noqa: E501
+                f"Currently only handling one choice, received {len(response.choices)}",
+            )
 
         is_function_call = (
             response.object == "chat.completion"
@@ -173,7 +174,7 @@ class MistralAICompletionWrapperBase(ABC):
             or is_legacy_streaming
             or is_non_streaming
             or is_legacy_non_streaming
-        ), f"Unexpected response object: {response.object}"  # noqa: E501
+        ), f"Unexpected response object: {response.object}"
 
         if is_streaming or is_legacy_streaming:
             return MistralAICompletionResponse(
@@ -235,7 +236,7 @@ class MistralAICompletion(MistralAICompletionWrapperBase):
                     created=chunk.data.created,
                     content="",
                     finish_reason=chunk.data.choices[0].finish_reason,  # last finish reason
-                )
+                ),
             )
             end_time = time.time()
             if hasattr(chunk, "data"):
@@ -340,9 +341,7 @@ class MistralAITools(MistralAICompletionWrapperBase):
             model: str | None = None,
             **model_kwargs: dict,
         ) -> MistralAIToolsResponse | MistralAICompletionResponse:
-        """
-        For example, MistralAICompletionResponse can be returned if `auto` and unrelated question.
-        """
+        """Call the MistralAI Tools API and return the response."""
         model = model or self.model
         model_parameters = model_kwargs or self.model_parameters
         start_time = time.time()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ faker~=18.9
 joblib~=1.4
 markdownify~=0.11
 markdown~=3.4
+mistralai~=1.1
 numpy~=1.26
 openai~=1.25
 pandas~=2.2

--- a/scripts/dev_requirements.txt
+++ b/scripts/dev_requirements.txt
@@ -9,3 +9,4 @@ ruff~=0.6
 tensorflow~=2.15
 tomlkit~=0.12
 ruamel.yaml~=0.18
+mistralai~=1.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -502,7 +502,7 @@ class AsyncMockOpenAI:
 
                 response = self.fake_responses[self.response_index]
                 self.response_index += 1
-                model = kwargs.get('model', None)
+                model = kwargs.get('model')
 
                 if stream:
                     if self.legacy:

--- a/tests/test_mistralai.py
+++ b/tests/test_mistralai.py
@@ -190,8 +190,8 @@ def test_MistralAITools(function_weather: Function, function_stocks: Function): 
         {
             "role": "user",
             "content": "What's the weather like in Boston today in degrees F?",
-        }
-    ]  # noqa: E501
+        },
+    ]
     response = model(
         messages=messages,
         tools=tools,
@@ -215,9 +215,10 @@ def test_MistralAITools(function_weather: Function, function_stocks: Function): 
     }
 
 
-def test_MistralAITools__unrelated_prompt__auto(
-    function_weather: Function, function_stocks: Function
-):  # noqa
+def test_MistralAITools__unrelated_prompt__auto(  # noqa
+    function_weather: Function,
+    function_stocks: Function,
+) -> None:
     """
     When the prompt is unrelated to any tool and the tool_choice is 'auto', then we will get
     a MistralAICompletionResponse object rather than a MistralAIToolResponse object.
@@ -248,9 +249,10 @@ def test_MistralAITools__unrelated_prompt__auto(
     assert response.content
 
 
-def test_MistralAITools__unrelated_prompt__required(
-    function_weather: Function, function_stocks: Function
-):  # noqa
+def test_MistralAITools__unrelated_prompt__required(  # noqa
+    function_weather: Function,
+    function_stocks: Function,
+) -> None:
     """
     When the prompt is unrelated to any tool and the tool_choice is 'required', then we will get
     a MistralAIToolResponse object, because `required` means that a tool must be returned.
@@ -271,9 +273,10 @@ def test_MistralAITools__unrelated_prompt__required(
     assert isinstance(response, MistralAIToolsResponse)
 
 
-def test_MistralAITools__unrelated_prompt__none(
-    function_weather: Function, function_stocks: Function
-):  # noqa
+def test_MistralAITools__unrelated_prompt__none(  # noqa
+    function_weather: Function,
+    function_stocks: Function,
+):
     tools = [
         function_weather.to_dict(),
         function_stocks.to_dict(),

--- a/tests/test_mistralai.py
+++ b/tests/test_mistralai.py
@@ -1,6 +1,7 @@
 """Tests Mistral classes."""
 
 import os
+import pytest
 from mistralai import Mistral
 from pydantic import BaseModel
 from llm_eval.mistralai import (
@@ -49,7 +50,7 @@ def test__MistralAIResponse__BaseModel_metadata_model_dump():  # noqa
         "finish_reason": None,
     }
 
-
+@pytest.mark.skipif('MISTRAL_API_KEY' not in os.environ, reason="MISTRAL_API_KEY not set in environment variables")  # noqa
 def test__MistralAICompletionWrapper() -> None:  # noqa
     client = Mistral(api_key=os.getenv("MISTRAL_API_KEY"))
     expected_response = "testing testing"
@@ -85,7 +86,7 @@ def test__MistralAICompletionWrapper() -> None:  # noqa
     assert response.usage["completion_tokens"] == 1
     assert response.usage["total_tokens"] > 0
 
-
+@pytest.mark.skipif('MISTRAL_API_KEY' not in os.environ, reason="MISTRAL_API_KEY not set in environment variables")  # noqa
 def test__MistralAICompletionWrapper__streaming() -> None:  # noqa
     # test valid parameters for streaming
     callback_chunks = []
@@ -132,7 +133,7 @@ def test__MistralAICompletionWrapper__streaming() -> None:  # noqa
     assert response.finish_reason == "length"
     assert callback_chunks[-1].finish_reason == "length"
 
-
+@pytest.mark.skipif('MISTRAL_API_KEY' not in os.environ, reason="MISTRAL_API_KEY not set in environment variables")  # noqa
 def test_Function__get_current_weather__to_dict(function_weather: Function):  # noqa
     assert function_weather.to_dict() == {
         "type": "function",
@@ -153,7 +154,7 @@ def test_Function__get_current_weather__to_dict(function_weather: Function):  # 
         },
     }
 
-
+@pytest.mark.skipif('MISTRAL_API_KEY' not in os.environ, reason="MISTRAL_API_KEY not set in environment variables")  # noqa
 def test_Function__get_current_stocks__to_dict(function_stocks: Function):  # noqa
     assert function_stocks.to_dict() == {
         "type": "function",
@@ -173,7 +174,7 @@ def test_Function__get_current_stocks__to_dict(function_stocks: Function):  # no
         },
     }
 
-
+@pytest.mark.skipif('MISTRAL_API_KEY' not in os.environ, reason="MISTRAL_API_KEY not set in environment variables")  # noqa
 def test_MistralAITools(function_weather: Function, function_stocks: Function):  # noqa
     tools = [
         function_weather.to_dict(),
@@ -214,7 +215,7 @@ def test_MistralAITools(function_weather: Function, function_stocks: Function): 
         "unit": "fahrenheit",
     }
 
-
+@pytest.mark.skipif('MISTRAL_API_KEY' not in os.environ, reason="MISTRAL_API_KEY not set in environment variables")  # noqa
 def test_MistralAITools__unrelated_prompt__auto(  # noqa
     function_weather: Function,
     function_stocks: Function,
@@ -248,7 +249,7 @@ def test_MistralAITools__unrelated_prompt__auto(  # noqa
     assert response.usage["total_tokens"] > 0
     assert response.content
 
-
+@pytest.mark.skipif('MISTRAL_API_KEY' not in os.environ, reason="MISTRAL_API_KEY not set in environment variables")  # noqa
 def test_MistralAITools__unrelated_prompt__required(  # noqa
     function_weather: Function,
     function_stocks: Function,
@@ -272,7 +273,7 @@ def test_MistralAITools__unrelated_prompt__required(  # noqa
     )
     assert isinstance(response, MistralAIToolsResponse)
 
-
+@pytest.mark.skipif('MISTRAL_API_KEY' not in os.environ, reason="MISTRAL_API_KEY not set in environment variables")  # noqa
 def test_MistralAITools__unrelated_prompt__none(  # noqa
     function_weather: Function,
     function_stocks: Function,

--- a/tests/test_mistralai.py
+++ b/tests/test_mistralai.py
@@ -1,0 +1,300 @@
+"""Tests Mistral classes."""
+
+import os
+from mistralai import Mistral
+from pydantic import BaseModel
+from llm_eval.mistralai import (
+    MistralAICompletion,
+    MistralAICompletionResponse,
+    MistralAIResponse,
+    MistralAIToolsResponse,
+    MistralAITools,
+)
+from llm_eval.openai import Function
+
+
+def test__MistralAIResponse__dict_metadata_model_dump():  # noqa
+    response = MistralAIResponse(
+        object_name="test name",
+        model="test model",
+        created=123456,
+        metadata={"test_1": "test", "test_2": 1},
+        finish_reason="length",
+    )
+    assert response.model_dump() == {
+        "object_name": "test name",
+        "model": "test model",
+        "created": 123456,
+        "metadata": {"test_1": "test", "test_2": 1},
+        "finish_reason": "length",
+    }
+
+
+def test__MistralAIResponse__BaseModel_metadata_model_dump():  # noqa
+    class Metadata(BaseModel):
+        test_1: str
+        test_2: int
+
+    response = MistralAIResponse(
+        object_name="test name",
+        model="test model",
+        created=123456,
+        metadata=Metadata(test_1="test", test_2=1),
+    )
+    assert response.model_dump() == {
+        "object_name": "test name",
+        "model": "test model",
+        "created": 123456,
+        "metadata": {"test_1": "test", "test_2": 1},
+        "finish_reason": None,
+    }
+
+
+def test__MistralAICompletionWrapper() -> None:  # noqa
+    client = Mistral(api_key=os.getenv("MISTRAL_API_KEY"))
+    expected_response = "testing testing"
+    messages = [{"role": "user", "content": f"Repeat: '{expected_response}'"}]
+
+    model = MistralAICompletion(
+        client=client,
+        model="ministral-8b-latest",
+        temperature=0.1,
+    )
+    response = model(messages=messages)
+    assert expected_response in response.content.lower()
+    assert response.model is not None
+    assert response.role == "assistant"
+    assert response.finish_reason == "stop"
+    assert response.created is not None
+    assert response.duration_seconds > 0
+    assert response.usage is not None
+    assert response.usage["prompt_tokens"] > 0
+    assert response.usage["completion_tokens"] > 0
+    assert response.usage["total_tokens"] > 0
+
+    # max tokens == 1
+    response = model(messages=messages, max_tokens=1)
+    assert len(response.content.split()) == 1
+    assert response.model is not None
+    assert response.role == "assistant"
+    assert response.finish_reason == "length"  # stopped due to max_tokens
+    assert response.created is not None
+    assert response.duration_seconds > 0
+    assert response.usage is not None
+    assert response.usage["prompt_tokens"] > 0
+    assert response.usage["completion_tokens"] == 1
+    assert response.usage["total_tokens"] > 0
+
+
+def test__MistralAICompletionWrapper__streaming() -> None:  # noqa
+    # test valid parameters for streaming
+    callback_chunks = []
+
+    def streaming_callback(record) -> None:  # noqa: ANN001
+        nonlocal callback_chunks
+        callback_chunks.append(record)
+
+    client = Mistral(api_key=os.getenv("MISTRAL_API_KEY"))
+    model = MistralAICompletion(
+        client=client,
+        model="ministral-8b-latest",
+        stream_callback=streaming_callback,
+    )
+    expected_response = "testing testing"
+    messages = [{"role": "user", "content": f"Repeat: '{expected_response}'"}]
+    response = model(messages=messages)
+    assert expected_response in response.content.lower()
+    assert len(callback_chunks) >= 3  # 2 chunks + 1 empty chunk w/ finish_reason
+    assert response.content == "".join(x.content for x in callback_chunks)
+    assert response.role == "assistant"
+    assert response.model is not None
+    assert response.created is not None
+    assert response.duration_seconds > 0
+    assert response.finish_reason == "stop"
+    assert callback_chunks[-1].finish_reason == "stop"
+
+    # max_tokens == 1; only 1 chunk should be returned
+    callback_chunks = []
+
+    def streaming_callback(record) -> None:  # noqa: ANN001
+        nonlocal callback_chunks
+        callback_chunks.append(record)
+
+    response = model(messages=messages, max_tokens=1)
+    assert len(response.content.split()) == 1
+    assert len(callback_chunks) >= 2  # 1 chunk + 1 empty chunk w/ finish_reason
+    assert callback_chunks[-1].finish_reason is not None
+    assert response.content == "".join(x.content for x in callback_chunks)
+    assert response.role == "assistant"
+    assert response.model is not None
+    assert response.created is not None
+    assert response.duration_seconds > 0
+    assert response.finish_reason == "length"
+    assert callback_chunks[-1].finish_reason == "length"
+
+
+def test_Function__get_current_weather__to_dict(function_weather: Function):  # noqa
+    assert function_weather.to_dict() == {
+        "type": "function",
+        "function": {
+            "name": "get_current_weather",
+            "description": "Get the current weather in a given location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "The city and state, e.g. San Francisco, CA",
+                    },
+                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                },
+                "required": ["location"],
+            },
+        },
+    }
+
+
+def test_Function__get_current_stocks__to_dict(function_stocks: Function):  # noqa
+    assert function_stocks.to_dict() == {
+        "type": "function",
+        "function": {
+            "name": "get_current_stocks",
+            "description": "Get the current stock price of a given company",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "company": {
+                        "type": "string",
+                        "description": "The name of the company, e.g. Apple",
+                    },
+                },
+                "required": ["company"],
+            },
+        },
+    }
+
+
+def test_MistralAITools(function_weather: Function, function_stocks: Function):  # noqa
+    tools = [
+        function_weather.to_dict(),
+        function_stocks.to_dict(),
+    ]
+    model = MistralAITools(
+        client=Mistral(api_key=os.getenv("MISTRAL_API_KEY")),
+        model="ministral-8b-latest",
+    )
+    ####
+    # first interaction
+    ####
+    messages = [
+        {
+            "role": "user",
+            "content": "What's the weather like in Boston today in degrees F?",
+        }
+    ]  # noqa: E501
+    response = model(
+        messages=messages,
+        tools=tools,
+    )
+    assert isinstance(response, MistralAIToolsResponse)
+    assert "ministral-8b-latest" in response.model
+    assert response.role == "assistant"
+    assert response.finish_reason == "tool_calls"
+    assert response.created is not None
+    assert response.duration_seconds > 0
+    assert response.usage is not None
+    assert response.usage["prompt_tokens"] > 0
+    assert response.usage["completion_tokens"] > 0
+    assert response.usage["total_tokens"] > 0
+    assert len(response.tools) == 1
+    assert response.tools[0]["type"] == "function"
+    assert response.tools[0]["name"] == "get_current_weather"
+    assert response.tools[0]["arguments"] == {
+        "location": "Boston, MA",
+        "unit": "fahrenheit",
+    }
+
+
+def test_MistralAITools__unrelated_prompt__auto(
+    function_weather: Function, function_stocks: Function
+):  # noqa
+    """
+    When the prompt is unrelated to any tool and the tool_choice is 'auto', then we will get
+    a MistralAICompletionResponse object rather than a MistralAIToolResponse object.
+    """
+    tools = [
+        function_weather.to_dict(),
+        function_stocks.to_dict(),
+    ]
+    model = MistralAITools(
+        client=Mistral(api_key=os.getenv("MISTRAL_API_KEY")),
+        model="ministral-8b-latest",
+    )
+    response = model(
+        messages=[{"role": "user", "content": "How's it going?"}],
+        tools=tools,
+        tool_choice="auto",
+    )
+    assert isinstance(response, MistralAICompletionResponse)
+    assert "ministral-8b-latest" in response.model
+    assert response.role == "assistant"
+    assert response.finish_reason == "stop"
+    assert response.created is not None
+    assert response.duration_seconds > 0
+    assert response.usage is not None
+    assert response.usage["prompt_tokens"] > 0
+    assert response.usage["completion_tokens"] > 0
+    assert response.usage["total_tokens"] > 0
+    assert response.content
+
+
+def test_MistralAITools__unrelated_prompt__required(
+    function_weather: Function, function_stocks: Function
+):  # noqa
+    """
+    When the prompt is unrelated to any tool and the tool_choice is 'required', then we will get
+    a MistralAIToolResponse object, because `required` means that a tool must be returned.
+    """
+    tools = [
+        function_weather.to_dict(),
+        function_stocks.to_dict(),
+    ]
+    model = MistralAITools(
+        client=Mistral(api_key=os.getenv("MISTRAL_API_KEY")),
+        model="ministral-8b-latest",
+    )
+    response = model(
+        messages=[{"role": "user", "content": "How's it going?"}],
+        tools=tools,
+        tool_choice="required",
+    )
+    assert isinstance(response, MistralAIToolsResponse)
+
+
+def test_MistralAITools__unrelated_prompt__none(
+    function_weather: Function, function_stocks: Function
+):  # noqa
+    tools = [
+        function_weather.to_dict(),
+        function_stocks.to_dict(),
+    ]
+    model = MistralAITools(
+        client=Mistral(api_key=os.getenv("MISTRAL_API_KEY")),
+        model="ministral-8b-latest",
+    )
+    response = model(
+        messages=[{"role": "user", "content": "How's it going?"}],
+        tools=tools,
+        tool_choice="none",
+    )
+    assert isinstance(response, MistralAICompletionResponse)
+    assert "ministral-8b-latest" in response.model
+    assert response.role == "assistant"
+    assert response.finish_reason == "stop"
+    assert response.created is not None
+    assert response.duration_seconds > 0
+    assert response.usage is not None
+    assert response.usage["prompt_tokens"] > 0
+    assert response.usage["completion_tokens"] > 0
+    assert response.usage["total_tokens"] > 0
+    assert response.content

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -444,7 +444,6 @@ async def test__async_MockOpenAI_object_streaming__legacy_structure() -> None:  
 def test_num_tokens():  # noqa
     assert num_tokens(model='gpt-3.5-turbo-0613', value="This should be six tokens.") == 6
 
-
 def test_Function__get_current_weather__to_dict(function_weather: Function):  # noqa
     assert function_weather.to_dict() == {
         "type": "function",
@@ -539,7 +538,6 @@ def test_OpenAITools__unrelated_prompt__auto(function_weather: Function, functio
     assert response.usage['completion_tokens'] > 0
     assert response.usage['total_tokens'] > 0
     assert response.content
-
 
 def test_OpenAITools__unrelated_prompt__required(function_weather: Function, function_stocks: Function):  # noqa
     """

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -501,7 +501,7 @@ def test_OpenAITools(function_weather: Function, function_stocks: Function):  # 
     assert isinstance(response, OpenAIToolsResponse)
     assert 'gpt-4o-mini' in response.model
     assert response.role == 'assistant'
-    assert response.finish_reason == 'stop'
+    assert response.finish_reason == 'tool_calls'
     assert response.created is not None
     assert response.duration_seconds > 0
     assert response.usage is not None


### PR DESCRIPTION
A bit of a big PR, but to summarize:

1. I noticed a quite a bit of redundancy for each candidate, so I refactored it to inherit from a ServiceCandidate, and added four abstractmethods that update the functionality for the children classes

2. Because of that, `type` and `completion_character` are always in the metadata now
3. Adds mistralai.py with all the corresponding base models (mostly copy/paste from OpenAI and find/replace OpenAI with MistralAI, with a few tweaks, notably method name changes `chat.completion` -> `chat.complete`, `AsyncOpenAI` and `OpenAI` -> `Mistral`, and Mistral's streaming results in an object that is nested differently having a parent `data`.

4. I left out `Function` from mistralai.py; not sure if it's needed, and just inherited from openai


Example usage
```python
from llm_eval.candidates import MistralAICandidate
from llm_eval.eval import Eval

eval_ = Eval(
    input=[{"role": "user", "content": "What is the best French cheese?"}],
    checks=[
        # a ResponseData object is passed to all checks (Check or callable) from the Eval
        lambda data: "cheese"
        in data.response,
    ],
)

candidate = MistralAICandidate(model="ministral-8b-latest")
result = eval_(candidate)
```